### PR TITLE
Remove zdravomil and support betka

### DIFF
--- a/ucho/data/configuration/fedmsg-celerize-map.yaml
+++ b/ucho/data/configuration/fedmsg-celerize-map.yaml
@@ -1,8 +1,8 @@
 ---
 org.fedoraproject.prod.github.issue.comment:
   - routes:
-      task.zdravomil.run_linters_pr: queue.zdravomil
+      task.betka.pr_sync: queue.betka-fedora
 
 org.fedoraproject.prod.github.push:
   - routes:
-      task.zdravomil.run_linters_pr: queue.zdravomil
+      task.betka.master_sync: queue.betka-fedora


### PR DESCRIPTION
This commit removes zdravomil bot and adds betka bot for Fedora land.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>