### PR TITLE
Rename to `queue.betka.fedora`

### DIFF
--- a/ucho/data/configuration/fedmsg-celerize-map.yaml
+++ b/ucho/data/configuration/fedmsg-celerize-map.yaml
@@ -1,8 +1,8 @@
 ---
 org.fedoraproject.prod.github.issue.comment:
   - routes:
-      task.betka.pr_sync: queue.betka-fedora
+      task.betka.pr_sync: queue.betka.fedora
 
 org.fedoraproject.prod.github.push:
   - routes:
-      task.betka.master_sync: queue.betka-fedora
+      task.betka.master_sync: queue.betka.fedora


### PR DESCRIPTION
For some reason `queue.betka-fedora` does not send
tasks `task.betka.master_sync`.

I have build my own ucho https://hub.docker.com/r/phracek/ucho
and test it with betka by this PR
https://github.com/sclorg/betka/pull/10
and this works properly.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>